### PR TITLE
Add Openshift Dockerfile for ci image creation

### DIFF
--- a/openshift-hack/images/Dockerfile.openshift
+++ b/openshift-hack/images/Dockerfile.openshift
@@ -1,0 +1,13 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11 as builder
+
+WORKDIR /build
+COPY . .
+RUN make build
+
+FROM registry.ci.openshift.org/ocp/4.11:base
+
+LABEL description="KubeVirt Cloud Controller Manager"
+
+COPY --from=builder /build/bin/kubevirt-cloud-controller-manager /bin/kubevirt-cloud-controller-manager
+
+ENTRYPOINT [ "/bin/kubevirt-cloud-controller-manager" ]


### PR DESCRIPTION
This new Dockerfile is specific for the image used by Openshift and
Would be created from openshift/release